### PR TITLE
updated vignette info

### DIFF
--- a/README.md
+++ b/README.md
@@ -610,6 +610,7 @@ Thanks to the beauty of Github a few others have made contributions.
 * [Karl Broman](http://www.biostat.wisc.edu/~kbroman/) fixed some problems with license recommendations.
 * [Leo Collado Torres](http://www.biostat.jhsph.edu/~lcollado/#.UlP1O2TXis0) fixed some typos/added links
 * [Alyssa Frazee](http://alyssafrazee.com/) fixed typos/corrected grammar
+* [Robert M Flight](http://rmflight.github.io) corrected some information about writing vignettes.
 
 ### Footnotes
 


### PR DESCRIPTION
I modified the vignette info to make it consistent, Rmd for html, and Rnw for pdf, and the location for vignette files based on current R package guidelines.
